### PR TITLE
Add a broacast receiver

### DIFF
--- a/test-butler-app/src/main/AndroidManifest.xml
+++ b/test-butler-app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <!-- Note: sharedUserId is required to make this app run as the same Linux user as system apps -->
 <manifest
     package="com.linkedin.android.testbutler"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:sharedUserId="android.uid.system"
-    tools:ignore="ProtectedPermissions">
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          android:sharedUserId="android.uid.system"
+          tools:ignore="ProtectedPermissions">
 
     <!-- Required for adding a custom IActivityController class -->
     <uses-permission android:name="android.permission.SET_ACTIVITY_WATCHER"/>
@@ -31,6 +31,9 @@
             android:exported="true"
             tools:ignore="ExportedService"/>
 
+        <receiver
+            android:name=".ButlerReceiver"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerReceiver.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerReceiver.java
@@ -1,0 +1,13 @@
+package com.linkedin.android.testbutler;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class ButlerReceiver extends BroadcastReceiver {
+
+	@Override
+	public void onReceive(final Context context, final Intent intent) {
+		context.startService(new Intent(context, ButlerService.class).putExtras(intent.getExtras()));
+	}
+}


### PR DESCRIPTION
Allow setting location mode and animation enabled state persistently via an Intent sent with adb.

For example:
```sh
adb shell am broadcast -n com.linkedin.android.testbutler/.ButlerReceiver --ei location_mode 1 --ez disable_animations false
```

Reviewer @jpkrause