### PR TITLE
Correct example to use @{Before/After] methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ public class ExampleTestRunner extends AndroidJUnitRunner {
 To change settings on the device from your tests, just use the methods in the `TestButler` class. For example:
 
 ```java
-@BeforeClass
+@Before
 public static void setupClass() {
   TestButler.setLocationMode(Settings.Secure.LOCATION_MODE_OFF);
 }
@@ -98,7 +98,7 @@ public void verifyBehaviorWithNoLocation() {
   // ...
 }
 
-@AfterClass
+@After
 public static void teardownClass() {
   TestButler.setLocationMode(Settings.Secure.LOCATION_MODE_HIGH_ACCURACY);
 }


### PR DESCRIPTION
This is so that the test suite will report exceptions when doing TestButler methods if the APK isn't installed. See #29 