### PR TITLE
Fix #2 - Add ability to enable and disable the system Spell Checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Version 1.2.0-SNAPSHOT
+- Add api for enabling and disabling the spell checker during tests
+
 ## Version 1.1.0 (2016-11-07)
 
 - Add api for granting runtime permissions on API 23+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.2.0-SNAPSHOT
 - Add api for enabling and disabling the spell checker during tests
+- Disable spell checker by default during tests
 
 ## Version 1.1.0 (2016-11-07)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ org.gradle.daemon=false
 # org.gradle.parallel=true
 
 GROUP_ID=com.linkedin.testbutler
-VERSION_NAME=1.1.1-SNAPSHOT
+VERSION_NAME=1.2.0-SNAPSHOT

--- a/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -31,4 +31,6 @@ interface ButlerApi {
     boolean setGsmState(boolean enabled);
 
     boolean grantPermission(String packageName, String permission);
+
+    boolean setSpellCheckerState(boolean enabled);
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -121,7 +121,7 @@ public class ButlerService extends Service {
         permissionGranter = new PermissionGranter();
 
         spellCheckerDisabler = new SpellCheckerDisabler();
-        spellCheckerDisabler.saveLocationServicesState(getContentResolver());
+        spellCheckerDisabler.saveSpellCheckerState(getContentResolver());
         // Disable spell checker by default
         spellCheckerDisabler.setSpellChecker(getContentResolver(), false);
 
@@ -153,7 +153,7 @@ public class ButlerService extends Service {
         NoDialogActivityController.uninstall();
 
         // Reset the spell checker to the original state
-        spellCheckerDisabler.restoreLocationServicesState(getContentResolver());
+        spellCheckerDisabler.restoreSpellCheckerState(getContentResolver());
     }
 
     @Nullable

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -42,6 +42,7 @@ public class ButlerService extends Service {
     private LocationServicesChanger locationServicesChanger;
     private GsmDataDisabler gsmDataDisabler;
     private PermissionGranter permissionGranter;
+    private SpellCheckerDisabler spellCheckerDisabler;
 
     private WifiManager.WifiLock wifiLock;
     private PowerManager.WakeLock wakeLock;
@@ -72,6 +73,11 @@ public class ButlerService extends Service {
         @Override
         public boolean grantPermission(String packageName, String permission) throws RemoteException {
             return permissionGranter.grantPermission(ButlerService.this, packageName, permission);
+        }
+
+        @Override
+        public boolean setSpellCheckerState(boolean enabled) {
+            return spellCheckerDisabler.setSpellChecker(getContentResolver(), enabled);
         }
     };
 
@@ -114,6 +120,11 @@ public class ButlerService extends Service {
         gsmDataDisabler = new GsmDataDisabler();
         permissionGranter = new PermissionGranter();
 
+        spellCheckerDisabler = new SpellCheckerDisabler();
+        spellCheckerDisabler.saveLocationServicesState(getContentResolver());
+        // Disable spell checker by default
+        spellCheckerDisabler.setSpellChecker(getContentResolver(), false);
+
         // Install custom IActivityController to prevent system dialogs from appearing if apps crash or ANR
         NoDialogActivityController.install();
     }
@@ -140,6 +151,9 @@ public class ButlerService extends Service {
 
         // Uninstall our IActivityController to resume normal Activity behavior
         NoDialogActivityController.uninstall();
+
+        // Reset the spell checker to the original state
+        spellCheckerDisabler.restoreLocationServicesState(getContentResolver());
     }
 
     @Nullable

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2016 LinkedIn Corp.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.android.testbutler;
+
+import android.content.ContentResolver;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+/**
+ * A helper class for disabling or enabling the system spell checker
+ */
+public class SpellCheckerDisabler {
+
+    private static final String TAG = SpellCheckerDisabler.class.getSimpleName();
+
+    // The constant in Settings.Secure is marked with @hide, so we can't use it
+    private static final String SPELL_CHECKER_SETTING = "spell_checker_enabled";
+
+    private boolean originalSpellCheckerMode;
+
+    /**
+     * Should be called before starting tests, to save original spell checker state
+     */
+    @SuppressWarnings("deprecation")
+    void saveLocationServicesState(@NonNull ContentResolver contentResolver) {
+        try {
+            originalSpellCheckerMode = Settings.Secure.getInt(contentResolver, SPELL_CHECKER_SETTING) == 1;
+        } catch (Settings.SettingNotFoundException e) {
+            Log.e(TAG, "Error reading location mode settings!", e);
+        }
+    }
+
+    /**
+     * Should be called after testing completes, to restore original spell checker state
+     */
+    void restoreLocationServicesState(@NonNull ContentResolver contentResolver) {
+        setSpellChecker(contentResolver, originalSpellCheckerMode);
+    }
+
+    /**
+     * Enable or disable the system spell checker
+     * @param resolver the {@link ContentResolver} used to modify settings
+     * @param enabled The desired state of the Spell Checker service
+     * @return true if the value was set, false otherwise
+     */
+    public boolean setSpellChecker(@NonNull ContentResolver resolver, boolean enabled) {
+        int val = enabled ? 1 : 0;
+        return Settings.Secure.putInt(resolver, SPELL_CHECKER_SETTING, val);
+    }
+}

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
@@ -36,18 +36,18 @@ public class SpellCheckerDisabler {
      * Should be called before starting tests, to save original spell checker state
      */
     @SuppressWarnings("deprecation")
-    void saveLocationServicesState(@NonNull ContentResolver contentResolver) {
+    void saveSpellCheckerState(@NonNull ContentResolver contentResolver) {
         try {
             originalSpellCheckerMode = Settings.Secure.getInt(contentResolver, SPELL_CHECKER_SETTING) == 1;
         } catch (Settings.SettingNotFoundException e) {
-            Log.e(TAG, "Error reading location mode settings!", e);
+            Log.e(TAG, "Error reading spell checker setting!", e);
         }
     }
 
     /**
      * Should be called after testing completes, to restore original spell checker state
      */
-    void restoreLocationServicesState(@NonNull ContentResolver contentResolver) {
+    void restoreSpellCheckerState(@NonNull ContentResolver contentResolver) {
         setSpellChecker(contentResolver, originalSpellCheckerMode);
     }
 

--- a/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -31,4 +31,6 @@ interface ButlerApi {
     boolean setGsmState(boolean enabled);
 
     boolean grantPermission(String packageName, String permission);
+
+    boolean setSpellCheckerState(boolean enabled);
 }

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -247,6 +247,21 @@ public class TestButler {
     }
 
     /**
+     * Enable or disable the system spell checker
+     *
+     * @param enabled What state the spell checker should be set to
+     */
+    public static void setSpellCheckerEnabled(boolean enabled) {
+        try {
+            if (!butlerApi.setSpellCheckerState(enabled)) {
+                throw new IllegalStateException("Failed to set spell checker!");
+            }
+        } catch (RemoteException e) {
+            throw new IllegalStateException("Failed to communicate with ButlerService", e);
+        }
+    }
+
+    /**
      * A helper method for granting runtime permissions to apps under test on API 23+
      * <p>
      * Note: Before API 23, this method is a no-op


### PR DESCRIPTION
This adds the ability to toggle the spell checker setting for tests. This is useful as sometimes the spell checker dialog can appear during tests and cause tests to fail.

No tests were added for this feature in this commit. Testing the spell checker is difficult to automate -- Android allows you to provide a replacement for the system spell checker, but it must be manually enabled by the user. Adding code to allow this in tests would add more code that could break, making the test more dangerous than productive.