### PR TITLE
Add keyboard disabler

### DIFF
--- a/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -33,4 +33,6 @@ interface ButlerApi {
     boolean grantPermission(String packageName, String permission);
 
     boolean setSpellCheckerState(boolean enabled);
+
+    boolean setSoftKeyboardState(boolean enabled);
 }

--- a/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -34,5 +34,5 @@ interface ButlerApi {
 
     boolean setSpellCheckerState(boolean enabled);
 
-    boolean setShowImeWithHardKeyboard(boolean enabled);
+    boolean setShowImeWithHardKeyboardState(boolean enabled);
 }

--- a/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -34,5 +34,5 @@ interface ButlerApi {
 
     boolean setSpellCheckerState(boolean enabled);
 
-    boolean setSoftKeyboardState(boolean enabled);
+    boolean setShowImeWithHardKeyboard(boolean enabled);
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -43,7 +43,7 @@ public class ButlerService extends Service {
     private GsmDataDisabler gsmDataDisabler;
     private PermissionGranter permissionGranter;
     private SpellCheckerDisabler spellCheckerDisabler;
-    private SoftKeyboardDisabler softKeyboardDisabler;
+    private ShowImeWithHardKeyboardHelper showImeWithHardKeyboardHelper;
 
     private WifiManager.WifiLock wifiLock;
     private PowerManager.WakeLock wakeLock;
@@ -82,8 +82,8 @@ public class ButlerService extends Service {
         }
 
         @Override
-        public boolean setSoftKeyboardState(boolean enabled) {
-            return softKeyboardDisabler.setSoftKeyboard(getContentResolver(), enabled);
+        public boolean setShowImeWithHardKeyboard(boolean enabled) {
+            return showImeWithHardKeyboardHelper.setShowImeWithHardKeyboard(getContentResolver(), enabled);
         }
     };
 
@@ -131,9 +131,9 @@ public class ButlerService extends Service {
         // Disable spell checker by default
         spellCheckerDisabler.setSpellChecker(getContentResolver(), false);
 
-        softKeyboardDisabler = new SoftKeyboardDisabler();
-        softKeyboardDisabler.saveSoftKeyboardState(getContentResolver());
-        softKeyboardDisabler.setSoftKeyboard(getContentResolver(), false);
+        showImeWithHardKeyboardHelper = new ShowImeWithHardKeyboardHelper();
+        showImeWithHardKeyboardHelper.saveShowImeState(getContentResolver());
+        showImeWithHardKeyboardHelper.setShowImeWithHardKeyboard(getContentResolver(), false);
 
         // Install custom IActivityController to prevent system dialogs from appearing if apps crash or ANR
         NoDialogActivityController.install();
@@ -166,7 +166,7 @@ public class ButlerService extends Service {
         spellCheckerDisabler.restoreSpellCheckerState(getContentResolver());
 
         // Restore the original keyboard setting
-        softKeyboardDisabler.restoreSoftKeyboardState(getContentResolver());
+        showImeWithHardKeyboardHelper.restoreShowImeState(getContentResolver());
     }
 
     @Nullable

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -82,8 +82,8 @@ public class ButlerService extends Service {
         }
 
         @Override
-        public boolean setShowImeWithHardKeyboard(boolean enabled) {
-            return showImeWithHardKeyboardHelper.setShowImeWithHardKeyboard(getContentResolver(), enabled);
+        public boolean setShowImeWithHardKeyboardState(boolean enabled) {
+            return showImeWithHardKeyboardHelper.setShowImeWithHardKeyboardState(getContentResolver(), enabled);
         }
     };
 
@@ -133,7 +133,7 @@ public class ButlerService extends Service {
 
         showImeWithHardKeyboardHelper = new ShowImeWithHardKeyboardHelper();
         showImeWithHardKeyboardHelper.saveShowImeState(getContentResolver());
-        showImeWithHardKeyboardHelper.setShowImeWithHardKeyboard(getContentResolver(), false);
+        showImeWithHardKeyboardHelper.setShowImeWithHardKeyboardState(getContentResolver(), false);
 
         // Install custom IActivityController to prevent system dialogs from appearing if apps crash or ANR
         NoDialogActivityController.install();

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -43,6 +43,7 @@ public class ButlerService extends Service {
     private GsmDataDisabler gsmDataDisabler;
     private PermissionGranter permissionGranter;
     private SpellCheckerDisabler spellCheckerDisabler;
+    private SoftKeyboardDisabler softKeyboardDisabler;
 
     private WifiManager.WifiLock wifiLock;
     private PowerManager.WakeLock wakeLock;
@@ -78,6 +79,11 @@ public class ButlerService extends Service {
         @Override
         public boolean setSpellCheckerState(boolean enabled) {
             return spellCheckerDisabler.setSpellChecker(getContentResolver(), enabled);
+        }
+
+        @Override
+        public boolean setSoftKeyboardState(boolean enabled) {
+            return softKeyboardDisabler.setSoftKeyboard(getContentResolver(), enabled);
         }
     };
 
@@ -125,6 +131,10 @@ public class ButlerService extends Service {
         // Disable spell checker by default
         spellCheckerDisabler.setSpellChecker(getContentResolver(), false);
 
+        softKeyboardDisabler = new SoftKeyboardDisabler();
+        softKeyboardDisabler.saveSoftKeyboardState(getContentResolver());
+        softKeyboardDisabler.setSoftKeyboard(getContentResolver(), false);
+
         // Install custom IActivityController to prevent system dialogs from appearing if apps crash or ANR
         NoDialogActivityController.install();
     }
@@ -154,6 +164,9 @@ public class ButlerService extends Service {
 
         // Reset the spell checker to the original state
         spellCheckerDisabler.restoreSpellCheckerState(getContentResolver());
+
+        // Restore the original keyboard setting
+        softKeyboardDisabler.restoreSoftKeyboardState(getContentResolver());
     }
 
     @Nullable

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
@@ -21,11 +21,16 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 /**
- * A helper class for disabling or enabling the software keyboard
+ * A helper class for setting the ime keyboard
+ *
+ * This can be used to force the hardware ime keyboard, preventing most occurences of the software keyboard showing on
+ * the screen in tests
+ *
+ * Requires API 22+
  */
-public class SoftKeyboardDisabler {
+public class ShowImeWithHardKeyboardHelper {
 
-    private static final String TAG = SoftKeyboardDisabler.class.getSimpleName();
+    private static final String TAG = ShowImeWithHardKeyboardHelper.class.getSimpleName();
 
     // The constant in Settings.Secure is marked with @hide, so we can't use it
     private static final String SOFT_KEYBOARD_SETTING = "show_ime_with_hard_keyboard";
@@ -33,9 +38,9 @@ public class SoftKeyboardDisabler {
     private boolean originalSoftKeyboardMode;
 
     /**
-     * Should be called before starting tests, to save original software keyboard state
+     * Should be called before starting tests, to save original ime keyboard state
      */
-    void saveSoftKeyboardState(@NonNull ContentResolver contentResolver) {
+    void saveShowImeState(@NonNull ContentResolver contentResolver) {
         try {
             originalSoftKeyboardMode = Settings.Secure.getInt(contentResolver, SOFT_KEYBOARD_SETTING) == 1;
         } catch (Settings.SettingNotFoundException e) {
@@ -44,19 +49,19 @@ public class SoftKeyboardDisabler {
     }
 
     /**
-     * Should be called after testing completes, to restore original software keyboard state
+     * Should be called after testing completes, to restore original ime keyboard state
      */
-    void restoreSoftKeyboardState(@NonNull ContentResolver contentResolver) {
-        setSoftKeyboard(contentResolver, originalSoftKeyboardMode);
+    void restoreShowImeState(@NonNull ContentResolver contentResolver) {
+        setShowImeWithHardKeyboard(contentResolver, originalSoftKeyboardMode);
     }
 
     /**
-     * Enable or disable the system software keyboard
+     * Force the system to use the hardware keyboard
      * @param resolver the {@link ContentResolver} used to modify settings
-     * @param enabled The desired state of the keyboard
+     * @param enabled Whether to require the hardware keyboard or not
      * @return true if the value was set, false otherwise
      */
-    public boolean setSoftKeyboard(@NonNull ContentResolver resolver, boolean enabled) {
+    public boolean setShowImeWithHardKeyboard(@NonNull ContentResolver resolver, boolean enabled) {
         int val = enabled ? 1 : 0;
         return Settings.Secure.putInt(resolver, SOFT_KEYBOARD_SETTING, val);
     }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
@@ -23,8 +23,9 @@ import android.util.Log;
 /**
  * A helper class for setting the ime keyboard
  *
- * This can be used to force the hardware ime keyboard, preventing most occurences of the software keyboard showing on
- * the screen in tests
+ * This can be used to disable the software ime when the device already has a hardware keyboard. By default on API 22+
+ * emulators, the software keyboard will still be enabled even if the device is configured to include a hardware keyboard.
+ * Note that you must still configure your emulator to have a hardware keyboard before this setting will have any effect.
  *
  * Requires API 22+
  */
@@ -33,36 +34,40 @@ public class ShowImeWithHardKeyboardHelper {
     private static final String TAG = ShowImeWithHardKeyboardHelper.class.getSimpleName();
 
     // The constant in Settings.Secure is marked with @hide, so we can't use it
-    private static final String SOFT_KEYBOARD_SETTING = "show_ime_with_hard_keyboard";
+    private static final String SHOW_IME_SETTING = "show_ime_with_hard_keyboard";
 
-    private boolean originalSoftKeyboardMode;
+    private boolean originalShowImeMode;
 
     /**
-     * Should be called before starting tests, to save original ime keyboard state
+     * Should be called before starting tests, to save original ime state
      */
     void saveShowImeState(@NonNull ContentResolver contentResolver) {
         try {
-            originalSoftKeyboardMode = Settings.Secure.getInt(contentResolver, SOFT_KEYBOARD_SETTING) == 1;
+            originalShowImeMode = Settings.Secure.getInt(contentResolver, SHOW_IME_SETTING) == 1;
         } catch (Settings.SettingNotFoundException e) {
-            Log.e(TAG, "Error reading soft keyboard (" + SOFT_KEYBOARD_SETTING + ") setting!", e);
+            Log.e(TAG, "Error reading soft keyboard (" + SHOW_IME_SETTING + ") setting!", e);
         }
     }
 
     /**
-     * Should be called after testing completes, to restore original ime keyboard state
+     * Should be called after testing completes, to restore original ime state
      */
     void restoreShowImeState(@NonNull ContentResolver contentResolver) {
-        setShowImeWithHardKeyboard(contentResolver, originalSoftKeyboardMode);
+        setShowImeWithHardKeyboardState(contentResolver, originalShowImeMode);
     }
 
     /**
-     * Force the system to use the hardware keyboard
+     * Tell the system to prefer the hardware IME
+     *
+     * This method has no effect on API < 22
+     *
+     * You must have your emulator configured with a hardware IME, or this method has no effect
      * @param resolver the {@link ContentResolver} used to modify settings
      * @param enabled Whether to require the hardware keyboard or not
      * @return true if the value was set, false otherwise
      */
-    public boolean setShowImeWithHardKeyboard(@NonNull ContentResolver resolver, boolean enabled) {
+    public boolean setShowImeWithHardKeyboardState(@NonNull ContentResolver resolver, boolean enabled) {
         int val = enabled ? 1 : 0;
-        return Settings.Secure.putInt(resolver, SOFT_KEYBOARD_SETTING, val);
+        return Settings.Secure.putInt(resolver, SHOW_IME_SETTING, val);
     }
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/SoftKeyboardDisabler.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/SoftKeyboardDisabler.java
@@ -21,43 +21,43 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 /**
- * A helper class for disabling or enabling the system spell checker
+ * A helper class for disabling or enabling the software keyboard
  */
-public class SpellCheckerDisabler {
+public class SoftKeyboardDisabler {
 
-    private static final String TAG = SpellCheckerDisabler.class.getSimpleName();
+    private static final String TAG = SoftKeyboardDisabler.class.getSimpleName();
 
     // The constant in Settings.Secure is marked with @hide, so we can't use it
-    private static final String SPELL_CHECKER_SETTING = "spell_checker_enabled";
+    private static final String SOFT_KEYBOARD_SETTING = "show_ime_with_hard_keyboard";
 
-    private boolean originalSpellCheckerMode;
+    private boolean originalSoftKeyboardMode;
 
     /**
-     * Should be called before starting tests, to save original spell checker state
+     * Should be called before starting tests, to save original software keyboard state
      */
-    void saveSpellCheckerState(@NonNull ContentResolver contentResolver) {
+    void saveSoftKeyboardState(@NonNull ContentResolver contentResolver) {
         try {
-            originalSpellCheckerMode = Settings.Secure.getInt(contentResolver, SPELL_CHECKER_SETTING) == 1;
+            originalSoftKeyboardMode = Settings.Secure.getInt(contentResolver, SOFT_KEYBOARD_SETTING) == 1;
         } catch (Settings.SettingNotFoundException e) {
-            Log.e(TAG, "Error reading spell checker (" + SPELL_CHECKER_SETTING + ") setting!", e);
+            Log.e(TAG, "Error reading soft keyboard (" + SOFT_KEYBOARD_SETTING + ") setting!", e);
         }
     }
 
     /**
-     * Should be called after testing completes, to restore original spell checker state
+     * Should be called after testing completes, to restore original software keyboard state
      */
-    void restoreSpellCheckerState(@NonNull ContentResolver contentResolver) {
-        setSpellChecker(contentResolver, originalSpellCheckerMode);
+    void restoreSoftKeyboardState(@NonNull ContentResolver contentResolver) {
+        setSoftKeyboard(contentResolver, originalSoftKeyboardMode);
     }
 
     /**
-     * Enable or disable the system spell checker
+     * Enable or disable the system software keyboard
      * @param resolver the {@link ContentResolver} used to modify settings
-     * @param enabled The desired state of the Spell Checker service
+     * @param enabled The desired state of the keyboard
      * @return true if the value was set, false otherwise
      */
-    public boolean setSpellChecker(@NonNull ContentResolver resolver, boolean enabled) {
+    public boolean setSoftKeyboard(@NonNull ContentResolver resolver, boolean enabled) {
         int val = enabled ? 1 : 0;
-        return Settings.Secure.putInt(resolver, SPELL_CHECKER_SETTING, val);
+        return Settings.Secure.putInt(resolver, SOFT_KEYBOARD_SETTING, val);
     }
 }

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/GsmEnablerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/GsmEnablerTest.java
@@ -59,7 +59,6 @@ public class GsmEnablerTest {
         disableDataTransferAndCheck();
     }
 
-
     @Test
     public void disableAndEnableGsmDataTransmission() {
         //Precondition

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
@@ -34,14 +34,13 @@ import static org.junit.Assert.assertNotEquals;
 
 public class ShowImeWithHardKeyboardHelperTest {
 
-    @Rule
-    public ActivityTestRule<MainActivity> testRule = new ActivityTestRule<>(MainActivity.class);
+    @Rule public ActivityTestRule<MainActivity> testRule = new ActivityTestRule<>(MainActivity.class);
 
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
     @Test
     public void keyboardDoesNotShow() {
-        TestButler.setSoftKeyboardState(false);
-        EditText editText = (EditText)testRule.getActivity().findViewById(R.id.editText);
+        TestButler.setShowImeWithHardKeyboardState(false);
+        EditText editText = (EditText) testRule.getActivity().findViewById(R.id.editText);
 
         int before[] = new int[2];
         editText.getLocationOnScreen(before);
@@ -59,8 +58,8 @@ public class ShowImeWithHardKeyboardHelperTest {
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
     @Test
     public void keyboardDoesShow() {
-        TestButler.setSoftKeyboardState(true);
-        EditText editText = (EditText)testRule.getActivity().findViewById(R.id.editText);
+        TestButler.setShowImeWithHardKeyboardState(true);
+        EditText editText = (EditText) testRule.getActivity().findViewById(R.id.editText);
 
         int before[] = new int[2];
         editText.getLocationOnScreen(before);

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
@@ -16,6 +16,8 @@
 package com.linkedin.android.testbutler.demo;
 
 
+import android.os.Build;
+import android.support.test.filters.SdkSuppress;
 import android.support.test.rule.ActivityTestRule;
 import android.widget.EditText;
 import com.linkedin.android.testbutler.TestButler;
@@ -30,11 +32,12 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class SoftKeyboardDisablerTest {
+public class ShowImeWithHardKeyboardHelperTest {
 
     @Rule
     public ActivityTestRule<MainActivity> testRule = new ActivityTestRule<>(MainActivity.class);
 
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
     @Test
     public void keyboardDoesNotShow() {
         TestButler.setSoftKeyboardState(false);
@@ -53,6 +56,7 @@ public class SoftKeyboardDisablerTest {
         assertEquals(before[1], after[1]);
     }
 
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
     @Test
     public void keyboardDoesShow() {
         TestButler.setSoftKeyboardState(true);

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/SoftKeyboardDisablerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/SoftKeyboardDisablerTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2016 LinkedIn Corp.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.android.testbutler.demo;
+
+
+import android.support.test.rule.ActivityTestRule;
+import android.widget.EditText;
+import com.linkedin.android.testbutler.TestButler;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SoftKeyboardDisablerTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> testRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void keyboardDoesNotShow() {
+        TestButler.setSoftKeyboardState(false);
+        EditText editText = (EditText)testRule.getActivity().findViewById(R.id.editText);
+
+        int before[] = new int[2];
+        editText.getLocationOnScreen(before);
+
+        onView(withId(R.id.editText)).perform(click());
+
+        int after[] = new int[2];
+        editText.getLocationOnScreen(after);
+
+        // Check that the position has not changed at all
+        assertEquals(before[0], after[0]);
+        assertEquals(before[1], after[1]);
+    }
+
+    @Test
+    public void keyboardDoesShow() {
+        TestButler.setSoftKeyboardState(true);
+        EditText editText = (EditText)testRule.getActivity().findViewById(R.id.editText);
+
+        int before[] = new int[2];
+        editText.getLocationOnScreen(before);
+
+        onView(withId(R.id.editText)).perform(click());
+
+        int after[] = new int[2];
+        editText.getLocationOnScreen(after);
+
+        // Only check that the y position changed
+        assertNotEquals(before[1], after[1]);
+    }
+}

--- a/test-butler-demo/src/main/res/layout/activity_main.xml
+++ b/test-butler-demo/src/main/res/layout/activity_main.xml
@@ -23,7 +23,7 @@
     tools:context="com.linkedin.android.testbutler.demo.MainActivity">
 
     <EditText
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/app_name"
         android:layout_alignParentBottom="true"

--- a/test-butler-demo/src/main/res/layout/activity_main.xml
+++ b/test-butler-demo/src/main/res/layout/activity_main.xml
@@ -14,12 +14,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<LinearLayout
+<RelativeLayout
     android:id="@+id/activity_main"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context="com.linkedin.android.testbutler.demo.MainActivity">
-</LinearLayout>
+
+    <EditText
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:layout_alignParentBottom="true"
+        android:id="@+id/editText"/>
+</RelativeLayout>

--- a/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -33,4 +33,6 @@ interface ButlerApi {
     boolean grantPermission(String packageName, String permission);
 
     boolean setSpellCheckerState(boolean enabled);
+
+    boolean setSoftKeyboardState(boolean enabled);
 }

--- a/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -34,5 +34,5 @@ interface ButlerApi {
 
     boolean setSpellCheckerState(boolean enabled);
 
-    boolean setShowImeWithHardKeyboard(boolean enabled);
+    boolean setShowImeWithHardKeyboardState(boolean enabled);
 }

--- a/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -34,5 +34,5 @@ interface ButlerApi {
 
     boolean setSpellCheckerState(boolean enabled);
 
-    boolean setSoftKeyboardState(boolean enabled);
+    boolean setShowImeWithHardKeyboard(boolean enabled);
 }

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -268,7 +268,7 @@ public class TestButler {
      */
     public static void setSoftKeyboardState(boolean enabled) {
         try {
-            if (!butlerApi.setSoftKeyboardState(enabled)) {
+            if (!butlerApi.setShowImeWithHardKeyboard(enabled)) {
                 throw new IllegalStateException("Failed to set software keyboard!");
             }
         } catch (RemoteException e) {

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -251,10 +251,25 @@ public class TestButler {
      *
      * @param enabled What state the spell checker should be set to
      */
-    public static void setSpellCheckerEnabled(boolean enabled) {
+    public static void setSpellCheckerState(boolean enabled) {
         try {
             if (!butlerApi.setSpellCheckerState(enabled)) {
                 throw new IllegalStateException("Failed to set spell checker!");
+            }
+        } catch (RemoteException e) {
+            throw new IllegalStateException("Failed to communicate with ButlerService", e);
+        }
+    }
+
+    /**
+     * Enable or disable the system software keyboard
+     *
+     * @param enabled What state the software keyboard should be set to
+     */
+    public static void setSoftKeyboardState(boolean enabled) {
+        try {
+            if (!butlerApi.setSoftKeyboardState(enabled)) {
+                throw new IllegalStateException("Failed to set software keyboard!");
             }
         } catch (RemoteException e) {
             throw new IllegalStateException("Failed to communicate with ButlerService", e);

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -262,13 +262,16 @@ public class TestButler {
     }
 
     /**
-     * Enable or disable the system software keyboard
+     * Tell the system to prefer the hardware IME
      *
-     * @param enabled What state the software keyboard should be set to
+     * This method has no effect on API < 22
+     *
+     * You must have your emulator configured with a hardware IME, or this method has no effect
+     * @param enabled Whether to require the hardware keyboard or not
      */
-    public static void setSoftKeyboardState(boolean enabled) {
+    public static void setShowImeWithHardKeyboardState(boolean enabled) {
         try {
-            if (!butlerApi.setShowImeWithHardKeyboard(enabled)) {
+            if (!butlerApi.setShowImeWithHardKeyboardState(enabled)) {
                 throw new IllegalStateException("Failed to set software keyboard!");
             }
         } catch (RemoteException e) {


### PR DESCRIPTION
This adds a new feature to the TestButler API that allows users to disable the software keyboard during tests. Often when running UI tests, entering text can cause the keyboard to rise up. This is a major source of flakiness, so TestButler allows you to disable it.

Also made some minor changes to the spell check disabler.