### PR TITLE
Readme Update: Calling out that manual APK installation is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more background, read the Test Butler announcement [blog post](https://engin
 
 ## How does it work?
 
-Test Butler is a two-part project. It includes an Android library that your test code can depend on, as well as a companion Android app apk that must be installed on your Android emulator before running Test Butler.  You can build the app yourself from source, or download the binary from [Bintray](https://bintray.com/linkedin/maven/test-butler-app/)
+Test Butler is a two-part project. It includes an Android library that your test code can depend on, as well as a companion Android app apk that must be installed on your Android emulator before using Test Butler.  You can build the Test Butler APK yourself from source, or download the binary from [Bintray](https://bintray.com/linkedin/maven/test-butler-app/)
 
 The Test Butler library is a thin wrapper around an [AIDL interface](https://developer.android.com/guide/components/aidl.html) to give your tests a safe way to talk to the Test Butler app's service running in the background on the emulator.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more background, read the Test Butler announcement [blog post](https://engin
 
 ## How does it work?
 
-Test Butler is a two-part project. It includes an Android library that your test code can depend on, as well as a companion Android app apk that is installed on your Android emulator before running tests.
+Test Butler is a two-part project. It includes an Android library that your test code can depend on, as well as a companion Android app apk that must be installed on your Android emulator before running Test Butler.  You can build the app yourself from source, or download the binary from [Bintray](https://bintray.com/linkedin/maven/test-butler-app/)
 
 The Test Butler library is a thin wrapper around an [AIDL interface](https://developer.android.com/guide/components/aidl.html) to give your tests a safe way to talk to the Test Butler app's service running in the background on the emulator.
 


### PR DESCRIPTION
I was very confused on how the companion APK got installed based on the original wording.  I didn't know how it was working, but assumed that the APK was auto-installed after I added the `androidTestCompile` gradle dependency and the necessary lines in my custom `AndroidJUnitRunner`. This somewhat relates to the open issue of "auto-installing" the APK: https://github.com/linkedin/test-butler/issues/22

The goal of this PR is to point out that the separate APK is needed on the device to get Test Butler to work and that you are required to do that yourself at the current time.

