### PR TITLE
Add missing method to IActivityController.aidl

### DIFF
--- a/test-butler-app/src/main/aidl/android/app/IActivityController.aidl
+++ b/test-butler-app/src/main/aidl/android/app/IActivityController.aidl
@@ -46,6 +46,11 @@ interface IActivityController
             long timeMillis, String stackTrace);
 
     /**
+     * Early call as soon as an ANR is detected.
+     */
+    int appEarlyNotResponding(String processName, int pid, String annotation);
+
+    /**
      * An application process is not responding.  Return 0 to show the "app
      * not responding" dialog, 1 to continue waiting, or -1 to kill it
      * immediately.

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
@@ -67,6 +67,14 @@ class NoDialogActivityController extends IActivityController.Stub {
     }
 
     @Override
+    public int appEarlyNotResponding(String processName, int pid, String annotation) throws RemoteException {
+        Log.v(TAG, "appEarlyNotResponding: " + processName + ":" + pid + " " + annotation);
+        // return 0 to continue with normal ANR processing
+        // we'll block the ANR dialog from appearing later, when appNotResponding is called
+        return 0;
+    }
+
+    @Override
     public int appNotResponding(String processName, int pid, String processStats) throws RemoteException {
         Log.v(TAG, "appNotResponding: " + processName + ":" + pid + " " + processStats);
         // return -1 to kill the ANR-ing app immediately and prevent the system dialog from appearing


### PR DESCRIPTION
Somehow the original code missed the appEarlyNotResponding
method when copying the IActivityController.aidl interface
from AOSP into Test Butler. The result of this bug is that
Test Butler will crash if appEarlyNotResponding is ever
actually called by the system.

Fixes #60