### PR TITLE
Correct test example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ public void teardown() {
   TestButler.setLocationMode(Settings.Secure.LOCATION_MODE_HIGH_ACCURACY);
 }
 ```
+NB: See [gotchyas](#any-gotchas-to-look-out-for) above to see why `@BeforeClass` & `@AfterClass` aren't used here. 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ public class ExampleTestRunner extends AndroidJUnitRunner {
 To change settings on the device from your tests, just use the methods in the `TestButler` class. For example:
 
 ```java
-@BeforeClass
-public static void setupClass() {
+@Before
+public void setup() {
   TestButler.setLocationMode(Settings.Secure.LOCATION_MODE_OFF);
 }
 
@@ -103,8 +103,8 @@ public void verifyBehaviorWithNoLocation() {
   // ...
 }
 
-@AfterClass
-public static void teardownClass() {
+@After
+public void teardown() {
   TestButler.setLocationMode(Settings.Secure.LOCATION_MODE_HIGH_ACCURACY);
 }
 ```


### PR DESCRIPTION
Due to a bug in the Android test runner.

If the test butler apk isn't installed, and TestButler operations are done in `@{Before/After}Class`, it will fail the test suite with a cryptic error message. Using Test Butler in `@{Before/After}` does pick up the app not installed exception.

See https://issuetracker.google.com/issues/37057596 for relevant Android issue.

I've made an example to verify its behaviour here: https://github.com/Kisty/test-butler/commit/caac902f9dd0d1fde61559a6b74b49954b917db0 in the [before-after-class-failure-example branch](https://github.com/Kisty/test-butler/tree/before-after-class-failure-example)
