### PR TITLE
Update Setting Activity Controller

### DIFF
--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
@@ -133,8 +133,9 @@ class NoDialogActivityController extends IActivityController.Stub {
     /**
      * Attempts to set the activity controller
      *
-     * API 25, in some versions, contains an extra param in setActivityController
-     * If attempting without the updated params does not work, attempt with the new params
+     * On newer versions of Android, there is an extra parameter in setActivityController to
+     * identify if we're in monkey testing mode. See this commit:
+     * https://android.googlesource.com/platform/frameworks/base/+/4a18c26609df2c4230885acb64e92fb51aba70df%5E%21/#F0
      *
      * @throws Throwable if the activity controller cannot be set
      */


### PR DESCRIPTION
See: https://github.com/linkedin/test-butler/issues/66

* On API 25, it seems there are versions that contain `setActivityController` with two parameters, instead of one. (See: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/IActivityManager.aidl#175)
    * Added a method to attempt both method implementations. Start with the single param, and fall back to the 2 param implementation if that fails
    * The same `RuntimeException` will be thrown if both fail

@Kisty @drewhannay 