### PR TITLE
Update build to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ android:
   components:
   - tools
   - platform-tools
-  - android-25
-  - build-tools-25.0.2
+  - android-28
+  - build-tools-28.0.3
   - extra-android-m2repository
   - extra-android-support
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Download the latest .apk and .aar via Maven:
 
 or Gradle:
 ```
-    androidTestCompile 'com.linkedin.testbutler:test-butler-library:1.4.0'
+    androidTestImplementation 'com.linkedin.testbutler:test-butler-library:1.4.0'
 ```
 
 You can also download the apk file manually from [Bintray](https://bintray.com/linkedin/maven/test-butler-app/) if you prefer.

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,13 @@ import com.linkedin.gradle.DistributeTask
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0"
     }
 }
@@ -20,11 +21,11 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = '25.0.2'
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
     minSdkVersion = 14
-    targetSdkVersion = 25
-    supportLibrariesVersion = '25.3.1'
+    targetSdkVersion = 27
+    supportLibrariesVersion = '27.1.1'
 }
 
 artifactoryPublish.skip = true

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,18 @@ repositories {
     jcenter()
 }
 
+/*
+   maven plug-in transitively brings in guava 18.0 which creates errors in build due to missing method.
+   We will have to force the version to at least 22 to resolve it.
+ */
+configurations.runtimeClasspath {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'com.google.guava' && details.requested.name == 'guava') {
+            details.useVersion '22.0'
+        }
+    }
+}
+
 dependencies {
     compile gradleApi()
     compile localGroovy()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,15 +7,11 @@ repositories {
     jcenter()
 }
 
-/*
-   maven plug-in transitively brings in guava 18.0 which creates errors in build due to missing method.
-   We will have to force the version to at least 22 to resolve it.
- */
+// Our dependencies are pulling in older version of guava,
+// but AGP3 requires a higher version of guava. So, we force it here
 configurations.runtimeClasspath {
-    resolutionStrategy.eachDependency { details ->
-        if (details.requested.group == 'com.google.guava' && details.requested.name == 'guava') {
-            details.useVersion '22.0'
-        }
+    resolutionStrategy {
+        force 'com.google.guava:guava:23.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -59,13 +59,13 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 publishing {
     publications {
         ivyApk(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
         apk(MavenPublication) {
 
-            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
+            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -45,9 +45,9 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    doFirst {
+    android.applicationVariants.matching { variant -> variant.name == 'debug'}.all { variant ->
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        classpath += project.android.applicationVariants.toList().first().javaCompile.classpath
+        classpath += variant.getCompileClasspath(null)
     }
 }
 

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -34,7 +34,7 @@ android {
         textOutput 'stdout'
         abortOnError true
         warningsAsErrors true
-        disable 'OldTargetApi', 'GradleDependency'
+        disable 'OldTargetApi', 'GradleDependency', 'PrivateApi', 'WakelockTimeout'
     }
 }
 
@@ -45,7 +45,10 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    doFirst {
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        classpath += project.android.applicationVariants.toList().first().javaCompile.classpath
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -99,9 +99,10 @@ publishing {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
-    provided "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
+    compileOnly "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -132,7 +132,7 @@ public class ButlerService extends Service {
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         wakeLock = powerManager.newWakeLock(PowerManager.FULL_WAKE_LOCK
                 | PowerManager.ACQUIRE_CAUSES_WAKEUP
-                | PowerManager.ON_AFTER_RELEASE, "ButlerWakeLock");
+                | PowerManager.ON_AFTER_RELEASE, "TestButlerApp:WakeLock");
         wakeLock.acquire();
 
         gsmDataDisabler = new GsmDataDisabler();

--- a/test-butler-demo/build.gradle
+++ b/test-butler-demo/build.gradle
@@ -23,16 +23,17 @@ android {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
-    androidTestCompile project(':test-butler-library')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation project(':test-butler-library')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibrariesVersion}"
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibrariesVersion}"
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -38,9 +38,9 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    doFirst {
+    android.libraryVariants.matching { variant -> variant.name == 'debug'}.all { variant ->
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+        classpath += variant.getCompileClasspath(null)
     }
 }
 

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -92,9 +92,11 @@ publishing {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
-    provided "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
+    compileOnly "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
+    implementation 'junit:junit:4.12'
 }

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -38,7 +38,10 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    doFirst {
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
- Move to latest plugin versions including AGP 3.2.1
- Use api and implementation over compile in build.gradle
- Use compileSdkVersion 28 and build tools version 28.0.3