### PR TITLE
Migrated test-butler to AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Install the Test Butler apk on your emulator prior to running tests, then add th
 public class ExampleTestRunner extends AndroidJUnitRunner {
   @Override
   public void onStart() {
-      TestButler.setup(InstrumentationRegistry.getTargetContext());
+      TestButler.setup(ApplicationProvider.getApplicationContext());
       super.onStart();
   }
 
   @Override
   public void finish(int resultCode, Bundle results) {
-      TestButler.teardown(InstrumentationRegistry.getTargetContext());
+      TestButler.teardown(ApplicationProvider.getApplicationContext());
       super.finish(resultCode, results);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ ext {
     compileSdkVersion = 28
     buildToolsVersion = '28.0.3'
     minSdkVersion = 14
-    targetSdkVersion = 27
-    supportLibrariesVersion = '27.1.1'
+    targetSdkVersion = 28
+    supportLibrariesVersion = '1.0.0'
 }
 
 artifactoryPublish.skip = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ org.gradle.daemon=false
 
 GROUP_ID=com.linkedin.testbutler
 VERSION_NAME=1.4.1-SNAPSHOT
+
+android.useAndroidX=true

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -107,5 +107,5 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
+    compileOnly "androidx.annotation:annotation:${rootProject.ext.supportLibrariesVersion}"
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/AlwaysFinishActivitiesChanger.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/AlwaysFinishActivitiesChanger.java
@@ -19,7 +19,7 @@ import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -22,7 +22,7 @@ import android.net.wifi.WifiManager;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.RemoteException;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 /**

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ImmersiveModeConfirmationDisabler.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ImmersiveModeConfirmationDisabler.java
@@ -18,7 +18,7 @@ package com.linkedin.android.testbutler;
 
 import android.content.ContentResolver;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
 

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/LocationServicesChanger.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/LocationServicesChanger.java
@@ -21,7 +21,7 @@ import android.content.ContentResolver;
 import android.location.LocationManager;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
@@ -18,7 +18,7 @@ package com.linkedin.android.testbutler;
 import android.app.IActivityController;
 import android.content.Intent;
 import android.os.RemoteException;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 import android.os.Build;
 

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/PermissionGranter.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/PermissionGranter.java
@@ -20,7 +20,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.UserHandle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/RotationChanger.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/RotationChanger.java
@@ -17,7 +17,7 @@ package com.linkedin.android.testbutler;
 
 import android.content.ContentResolver;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.view.Surface;
 

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ShowImeWithHardKeyboardHelper.java
@@ -17,7 +17,7 @@ package com.linkedin.android.testbutler;
 
 import android.content.ContentResolver;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/SpellCheckerDisabler.java
@@ -17,7 +17,7 @@ package com.linkedin.android.testbutler;
 
 import android.content.ContentResolver;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/utils/ExceptionCreator.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/utils/ExceptionCreator.java
@@ -17,8 +17,8 @@ package com.linkedin.android.testbutler.utils;
 
 import android.os.Build;
 import android.os.RemoteException;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 public class ExceptionCreator {

--- a/test-butler-demo/build.gradle
+++ b/test-butler-demo/build.gradle
@@ -29,11 +29,11 @@ repositories {
 
 dependencies {
     androidTestImplementation project(':test-butler-library')
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0')
+    androidTestImplementation('androidx.test:rules:1.1.0')
+    androidTestImplementation("androidx.test:core:${rootProject.ext.supportLibrariesVersion}")
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibrariesVersion}"
+    implementation "androidx.appcompat:appcompat:${rootProject.ext.supportLibrariesVersion}"
 
     testImplementation 'junit:junit:4.12'
 }

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/AlwaysFinishActivitiesChangerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/AlwaysFinishActivitiesChangerTest.java
@@ -18,13 +18,14 @@ package com.linkedin.android.testbutler.demo;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 
 import com.linkedin.android.testbutler.TestButler;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +36,7 @@ public class AlwaysFinishActivitiesChangerTest {
 
     @Before
     public void setup() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         contentResolver = context.getContentResolver();
     }
 

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/AnimationDisablerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/AnimationDisablerTest.java
@@ -15,14 +15,16 @@
  */
 package com.linkedin.android.testbutler.demo;
 
-import android.support.test.InstrumentationRegistry;
 import com.linkedin.android.testbutler.TestButler;
+
 import org.junit.Test;
+
+import androidx.test.core.app.ApplicationProvider;
 
 public class AnimationDisablerTest {
 
     @Test
     public void disableAnimations() throws Exception {
-        TestButler.verifyAnimationsDisabled(InstrumentationRegistry.getTargetContext());
+        TestButler.verifyAnimationsDisabled(ApplicationProvider.getApplicationContext());
     }
 }

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/DemoTestRunner.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/DemoTestRunner.java
@@ -16,20 +16,22 @@
 package com.linkedin.android.testbutler.demo;
 
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnitRunner;
+
 import com.linkedin.android.testbutler.TestButler;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.runner.AndroidJUnitRunner;
 
 public class DemoTestRunner extends AndroidJUnitRunner {
     @Override
     public void onStart() {
-        TestButler.setup(InstrumentationRegistry.getTargetContext());
+        TestButler.setup(ApplicationProvider.getApplicationContext());
         super.onStart();
     }
 
     @Override
     public void finish(int resultCode, Bundle results) {
-        TestButler.teardown(InstrumentationRegistry.getTargetContext());
+        TestButler.teardown(ApplicationProvider.getApplicationContext());
         super.finish(resultCode, results);
     }
 }

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/GsmEnablerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/GsmEnablerTest.java
@@ -19,7 +19,6 @@ package com.linkedin.android.testbutler.demo;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.support.test.InstrumentationRegistry;
 
 import com.linkedin.android.testbutler.TestButler;
 import com.linkedin.android.testbutler.demo.utils.Waiter;
@@ -27,6 +26,8 @@ import com.linkedin.android.testbutler.demo.utils.Waiter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import static junit.framework.Assert.assertTrue;
 
@@ -37,7 +38,7 @@ public class GsmEnablerTest {
 
     @Before
     public void setup() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ImmersiveModeConfirmationDisablerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ImmersiveModeConfirmationDisablerTest.java
@@ -1,15 +1,15 @@
 package com.linkedin.android.testbutler.demo;
 
-import android.support.test.rule.ActivityTestRule;
+import androidx.test.rule.ActivityTestRule;
 import com.linkedin.android.testbutler.TestButler;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 public class ImmersiveModeConfirmationDisablerTest {
     @Rule public ActivityTestRule<MainActivity> testRule = new ActivityTestRule<>(MainActivity.class);

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/LocationServicesChangerTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/LocationServicesChangerTest.java
@@ -18,7 +18,7 @@ package com.linkedin.android.testbutler.demo;
 import android.content.Context;
 import android.location.LocationManager;
 import android.provider.Settings;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import com.linkedin.android.testbutler.TestButler;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class LocationServicesChangerTest {
 
     @Before
     public void setup() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         manager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     }
 

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/PermissionGranterTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/PermissionGranterTest.java
@@ -19,11 +19,14 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SdkSuppress;
-import android.support.v4.content.ContextCompat;
+
 import com.linkedin.android.testbutler.TestButler;
+
 import org.junit.Test;
+
+import androidx.core.content.ContextCompat;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.filters.SdkSuppress;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,7 +38,7 @@ public class PermissionGranterTest {
     @Test
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void successfullyGrantPermission() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
 
         long result = ContextCompat.checkSelfPermission(context, permission);
@@ -50,7 +53,7 @@ public class PermissionGranterTest {
     @Test(expected = IllegalArgumentException.class)
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void failWhenTryingToGrantNonDangerousPermission() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         String permission = Manifest.permission.ACCESS_WIFI_STATE;
 
         TestButler.grantPermission(context, permission);
@@ -59,7 +62,7 @@ public class PermissionGranterTest {
     @Test(expected = IllegalArgumentException.class)
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void failWhenTryingToGrantPermissionNotInManifest() {
-        Context context = InstrumentationRegistry.getTargetContext();
+        Context context = ApplicationProvider.getApplicationContext();
         String permission = Manifest.permission.ADD_VOICEMAIL;
 
         TestButler.grantPermission(context, permission);

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/ShowImeWithHardKeyboardHelperTest.java
@@ -17,16 +17,16 @@ package com.linkedin.android.testbutler.demo;
 
 
 import android.os.Build;
-import android.support.test.filters.SdkSuppress;
-import android.support.test.rule.ActivityTestRule;
+import androidx.test.filters.SdkSuppress;
+import androidx.test.rule.ActivityTestRule;
 import android.widget.EditText;
 import com.linkedin.android.testbutler.TestButler;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 
 import static org.junit.Assert.assertEquals;

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/utils/Waiter.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/utils/Waiter.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.android.testbutler.demo.utils;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public class Waiter {
     public static boolean wait(int retryCount, @NonNull DelayDependOnCount delayDependOnCount, @NonNull Predicate predicate) {

--- a/test-butler-demo/src/main/java/com/linkedin/android/testbutler/demo/MainActivity.java
+++ b/test-butler-demo/src/main/java/com/linkedin/android/testbutler/demo/MainActivity.java
@@ -17,7 +17,7 @@ package com.linkedin.android.testbutler.demo;
 
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -100,6 +100,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.android.support:support-annotations:${rootProject.ext.supportLibrariesVersion}"
+    compileOnly "androidx.annotation:annotation:${rootProject.ext.supportLibrariesVersion}"
     implementation 'junit:junit:4.12'
 }

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/AnimationAssertions.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/AnimationAssertions.java
@@ -20,7 +20,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -30,8 +30,8 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.os.RemoteException;
 import android.provider.Settings;
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.view.Surface;
 


### PR DESCRIPTION
- Migrated library to AndroidX.
- Replaced all occurances of com.android.support
  with its corresponding AndroidX components.
- Also removed usages of deprecated
  "InstrumentationRegistry.getTargetContext()" and used
  "ApplicationProvider#getApplicationContext()"