### PR TITLE
Use instrumentation target context

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Install the Test Butler apk on your emulator prior to running tests, then add th
 public class ExampleTestRunner extends AndroidJUnitRunner {
   @Override
   public void onStart() {
-      TestButler.setup(ApplicationProvider.getApplicationContext());
+      TestButler.setup(getTargetContext());
       super.onStart();
   }
 
   @Override
   public void finish(int resultCode, Bundle results) {
-      TestButler.teardown(ApplicationProvider.getApplicationContext());
+      TestButler.teardown(getTargetContext());
       super.finish(resultCode, results);
   }
 }

--- a/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/DemoTestRunner.java
+++ b/test-butler-demo/src/androidTest/java/com/linkedin/android/testbutler/demo/DemoTestRunner.java
@@ -19,19 +19,18 @@ import android.os.Bundle;
 
 import com.linkedin.android.testbutler.TestButler;
 
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnitRunner;
 
 public class DemoTestRunner extends AndroidJUnitRunner {
     @Override
     public void onStart() {
-        TestButler.setup(ApplicationProvider.getApplicationContext());
+        TestButler.setup(getTargetContext());
         super.onStart();
     }
 
     @Override
     public void finish(int resultCode, Bundle results) {
-        TestButler.teardown(ApplicationProvider.getApplicationContext());
+        TestButler.teardown(getTargetContext());
         super.finish(resultCode, results);
     }
 }


### PR DESCRIPTION
Use the target context from the runner preventing crashes when the Instrumentation is not yet registered (closes #86).