### PR TITLE
Enabled testing local maven artifacts and metadata

### DIFF
--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -97,6 +97,13 @@ publishing {
                     }
                 }
             }
+
+            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
     }
 }

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -90,6 +90,13 @@ publishing {
                     }
                 }
             }
+
+            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Running './gradlew publish' will create local maven repo with artifacts and metadata, under "build/repo" directory.

The change is safe and does not interfere with the current way you publish. It's similar to https://github.com/linkedin/shaky-android/pull/31/files