### PR TITLE
Allow test butler to run on Android Q

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 28
+    compileSdkVersion = 29
     buildToolsVersion = '28.0.3'
     minSdkVersion = 14
-    targetSdkVersion = 28
+    targetSdkVersion = 29
     supportLibrariesVersion = '1.0.0'
 }
 


### PR DESCRIPTION
Previously, test butler would crash when running on a Q device when trying to attain a keyguard lock. We have reached out to google to get their recommendation on how test butler can continue to provide the functionality it does for android Q. In the mean time, we can simply turn this particular piece off to allow running on Q. Also addressed a similar issue with the WifiLock where WIFI_MODE_FULL is now silently deprecated as a no-op call in Q (see https://developer.android.com/reference/android/net/wifi/WifiManager#WIFI_MODE_FULL).