### PR TITLE
Fixing lint warnings on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ android:
   components:
   - tools
   - platform-tools
-  - android-28
+  - android-29
   - build-tools-28.0.3
   - extra-android-m2repository
   - extra-android-support

--- a/test-butler-app-core/build.gradle
+++ b/test-butler-app-core/build.gradle
@@ -27,7 +27,7 @@ android {
         textOutput 'stdout'
         abortOnError true
         warningsAsErrors true
-        disable 'OldTargetApi', 'GradleDependency'
+        disable 'OldTargetApi', 'GradleDependency', 'PrivateApi', 'WakelockTimeout'
     }
 }
 

--- a/test-butler-app-core/src/main/java/com/linkedin/android/testbutler/CommonDeviceLocks.java
+++ b/test-butler-app-core/src/main/java/com/linkedin/android/testbutler/CommonDeviceLocks.java
@@ -44,7 +44,7 @@ class CommonDeviceLocks {
     void acquire(@NonNull Context context) {
         // Acquire a WifiLock to prevent wifi from turning off and breaking tests
         // NOTE: holding a WifiLock does NOT override a call to setWifiEnabled(false)
-        WifiManager wifiManager = (WifiManager) context.getSystemService(WIFI_SERVICE);
+        WifiManager wifiManager = (WifiManager) context.getApplicationContext().getSystemService(WIFI_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "ButlerWifiLock");
         } else {

--- a/test-butler-app-core/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
+++ b/test-butler-app-core/src/main/java/com/linkedin/android/testbutler/NoDialogActivityController.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
  * {@link NoDialogActivityController} disables the system dialogs for app crashes and ANRs so that other apps crashing
  * on an emulator will not prevent Espresso UI tests from running.
  * <p>
- * {@link IActivityController} is an interface provided by the Android OS to facilitate testing.
+ * IActivityController is an interface provided by the Android OS to facilitate testing.
  * If set, the class is called by the Android system and can prevent activities from starting
  * or resuming, as well as disable the default system dialogs that appear when an app crashes or
  * ANRs. An example of a class implementing this interface can be found in the AOSP class Monkey.java:
@@ -40,7 +40,7 @@ import java.lang.reflect.Method;
  * with the system signing key. The signing key for the stock emulators is openly available, so we can sign this
  * app with that key, but that means it can only be installed on stock emulators.
  * <p>
- * Note: In order to implement the {@link IActivityController} interface, a copy of the .aidl file is included
+ * Note: In order to implement the IActivityController interface, a copy of the .aidl file is included
  * in this project.
  */
 public class NoDialogActivityController extends IActivityController.Stub {
@@ -93,21 +93,21 @@ public class NoDialogActivityController extends IActivityController.Stub {
     }
 
     /**
-     * Install an instance of this class as the {@link IActivityController} to monitor the ActivityManager
+     * Install an instance of this class as the IActivityController to monitor the ActivityManager
      */
     public static void install() {
         setActivityController(new NoDialogActivityController());
     }
 
     /**
-     * Remove any installed {@link IActivityController} to reset the ActivityManager to the default state
+     * Remove any installed IActivityController to reset the ActivityManager to the default state
      */
     public static void uninstall() {
         setActivityController(null);
     }
 
     /**
-     * Use reflection to call the hidden api and set a custom {@link IActivityController}:
+     * Use reflection to call the hidden api and set a custom IActivityController:
      * ActivityManagerNative.getDefault().setActivityController(activityController);
      */
     private static void setActivityController(@Nullable IActivityController activityController) {

--- a/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/AdbDevice.java
+++ b/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/AdbDevice.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.android.testbutler;
 
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.util.Log;
@@ -74,6 +76,9 @@ class AdbDevice {
         }
     }
 
+    // Suppressing the serial identifier warning, as we need a guaranteed unique ID for all devices
+    @SuppressLint("HardwareIds")
+    @TargetApi(Build.VERSION_CODES.O)
     private static AdbDevice getDevicePreO(String host, int port) {
         try {
             String deviceId = Build.SERIAL;


### PR DESCRIPTION
Travis was not running for a while, and some lint warnings made it in. All of these warnings/errors are red herrings however:

- Added "PrivateApi" back to the disabled list for the test-butler-app-core module. The whole point of test butler is to invoke private apis.
- Added "WakelockTimeout" back to the disabled list for the test-butler-app-core module. Test butler intentionally grabs an untimed wakelock to keep the device on
- Ignored a specific use of Build.SERIAL. Usually this is not recommended to be used in favor of user controlled ids like AdvertiserID, but this is needed by the infra to uniquely identify devices when talking over adb for real device test butler. We need a guaranteed unique id.