### PR TITLE
Fix publications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,10 @@ artifactory {
         }
 
         defaults {
-            publications 'apk', 'lib', 'ivyLib', 'ivyApk'
+            publications 'apiLib', 'ivyApiLib',
+                    'lib', 'ivyLib',
+                    'apk', 'ivyApk',
+                    'physicalDeviceApk', 'ivyPhysicalDeviceApk'
         }
 
         publishArtifacts = true
@@ -54,5 +57,9 @@ artifactory {
 }
 
 task distributeBuild(type: DistributeTask) {
-    dependsOn ':artifactoryPublish', 'test-butler-app:artifactoryPublish', 'test-butler-library:artifactoryPublish'
+    dependsOn ':artifactoryPublish',
+            'test-butler-api:artifactoryPublish',
+            'test-butler-app:artifactoryPublish',
+            'test-butler-app-phsyical-devices:artifactoryPublish',
+            'test-butler-library:artifactoryPublish'
 }

--- a/test-butler-api/build.gradle
+++ b/test-butler-api/build.gradle
@@ -51,14 +51,14 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 publishing {
     publications {
-        ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+        ivyApiLib(IvyPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
-        lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+        apiLib(MavenPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-app-core/build.gradle
+++ b/test-butler-app-core/build.gradle
@@ -49,58 +49,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-publishing {
-    publications {
-        ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
-          artifact sourcesJar
-          artifact javadocJar
-        }
-
-        lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
-
-            artifact sourcesJar
-            artifact javadocJar
-
-            pom.withXml {
-                asNode().children().last() + {
-                    resolveStrategy = Closure.DELEGATE_FIRST
-                    description = 'A base library for stabilizing Android devices during testing'
-                    url 'https://github.com/linkedin/test-butler'
-                    scm {
-                        url 'https://github.com/linkedin/test-butler'
-                        connection 'scm:git:git://github.com/linkedin/test-butler.git'
-                        developerConnection 'https://github.com/linkedin/test-butler.git'
-                    }
-                    licenses {
-                        license {
-                            name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
-                            distribution 'repo'
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'com.linkedin'
-                            name 'LinkedIn Corp'
-                            email ''
-                        }
-                    }
-                }
-            }
-
-            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
-            repositories {
-                maven {
-                    url = "$rootProject.buildDir/repo"
-                }
-            }
-        }
-    }
-}
-
 repositories {
     google()
     jcenter()

--- a/test-butler-app-physical-devices/build.gradle
+++ b/test-butler-app-physical-devices/build.gradle
@@ -62,14 +62,14 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 publishing {
     publications {
-        ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+        ivyPhysicalDeviceApk(IvyPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.default.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
-        lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+        physicalDeviceApk(MavenPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.default.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -59,13 +59,13 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 publishing {
     publications {
         ivyApk(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.default.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
         apk(MavenPublication) {
 
-            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.compile.getAllDependencies())
+            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.default.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -52,13 +52,13 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 publishing {
     publications {
         ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
         lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.compile.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar


### PR DESCRIPTION
The current 2.0.1 release is broken for test-butler-library. It does not include test-butler-api as a dependency in the published ivy, and test-butler-api does not get published.