### PR TITLE
Fix broken publish artifact paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ artifactory {
         defaults {
             publications 'apiLib', 'ivyApiLib',
                     'lib', 'ivyLib',
-                    'apk', 'ivyApk'
-                    // 'physicalDeviceApk', 'ivyPhysicalDeviceApk'
+                    'apk', 'ivyApk',
+                    'physicalDeviceApk', 'ivyPhysicalDeviceApk'
         }
 
         publishArtifacts = true
@@ -60,6 +60,6 @@ task distributeBuild(type: DistributeTask) {
     dependsOn ':artifactoryPublish',
             'test-butler-api:artifactoryPublish',
             'test-butler-app:artifactoryPublish',
-            // 'test-butler-app-physical-devices:artifactoryPublish',
+            'test-butler-app-physical-devices:artifactoryPublish',
             'test-butler-library:artifactoryPublish'
 }

--- a/test-butler-api/build.gradle
+++ b/test-butler-api/build.gradle
@@ -50,15 +50,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 publishing {
+    def artifactFile = configurations.default.allArtifacts.files.singleFile
+    def artifactExt = artifactFile.name.tokenize('.').last()
     publications {
         ivyApiLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
         apiLib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-app-physical-devices/build.gradle
+++ b/test-butler-app-physical-devices/build.gradle
@@ -61,15 +61,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 publishing {
+    def artifactFile = android.applicationVariants.find { it.name == 'release' }.outputs.first().outputFile
+    def artifactExt = artifactFile.name.tokenize('.').last()
     publications {
         ivyPhysicalDeviceApk(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.default.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.default.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
         physicalDeviceApk(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.default.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.default.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-app/build.gradle
+++ b/test-butler-app/build.gradle
@@ -57,15 +57,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 publishing {
+    def artifactFile = android.applicationVariants.find { it.name == 'release' }.outputs.first().outputFile
+    def artifactExt = artifactFile.name.tokenize('.').last()
     publications {
         ivyApk(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.default.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.default.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
         apk(MavenPublication) {
 
-            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'apk', 'apk', null, new Date(), new File("$buildDir/outputs/apk/release/${project.getName()}-release.apk"), assemble), project.configurations.default.getAllDependencies())
+            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.default.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar

--- a/test-butler-library/build.gradle
+++ b/test-butler-library/build.gradle
@@ -50,15 +50,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 publishing {
+    def artifactFile = configurations.default.allArtifacts.files.singleFile
+    def artifactExt = artifactFile.name.tokenize('.').last()
     publications {
         ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
           artifact sourcesJar
           artifact javadocJar
         }
 
         lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), artifactExt, artifactExt, null, new Date(), artifactFile, assemble), project.configurations.releaseRuntimeClasspath.getAllDependencies())
 
             artifact sourcesJar
             artifact javadocJar


### PR DESCRIPTION
Re-enables physical-device-test-butler-app.
For libraries, using: `configurations.default.allArtifacts.files.singleFile`
For APKs, using: `android.applicationVariants.find { it.name == 'release' }.outputs.first().outputFile`
From now on, artifact paths and extensions are automatically configured. Sorry for breaking publishing :(