### PR TITLE
Fix Physical Device Test Butler for API 21 and 22

### DIFF
--- a/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/AdbDevice.java
+++ b/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/AdbDevice.java
@@ -33,7 +33,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -69,59 +68,69 @@ class AdbDevice {
      */
     @NonNull
     static AdbDevice getCurrentDevice(@NonNull String host, int port) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return getDevicePreO(host, port);
-        } else {
-            return findCurrentDevice(host, port);
-        }
-    }
-
-    // Suppressing the serial identifier warning, as we need a guaranteed unique ID for all devices
-    @SuppressLint("HardwareIds")
-    @TargetApi(Build.VERSION_CODES.O)
-    private static AdbDevice getDevicePreO(String host, int port) {
         try {
-            String deviceId = Build.SERIAL;
-            AdbDevice adbDevice = new AdbDevice(host, port, deviceId);
-            // test the connection...
-            adbDevice.shellCommand("echo").get();
-            return adbDevice;
-        } catch (Exception e) {
-            Log.w(TAG, "Could not execute command using device serial number, assuming this device is the only device attached...");
-            return new AdbDevice(host, port, null);
-        }
-    }
-
-    private static AdbDevice findCurrentDevice(String host, int port) {
-        // to find this device without using the device serial, we log a random string and then
-        // check every device's logcat for that string.
-        try {
-            String key = String.format("deviceKey=%s", Integer.toHexString(new Random().nextInt()));
             List<AdbDevice> devices = AdbDevice.getDevices(host, port);
-            for (AdbDevice device : devices) {
-                Calendar cal = Calendar.getInstance();
-                cal.add(Calendar.SECOND, -5);  // so that -t <timestamp> has some buffer
-                String timestamp = LOGCAT_DATE_FORMAT.format(cal.getTime());
 
-                Log.v(TAG, key);
-
-                // find the above ButlerService log entry
-                String log = device.shellCommand("logcat",
-                        "-t", timestamp,    // only entries from last 5 seconds
-                        "-s",               // silence all tags (besides TAG)
-                        "-e", "deviceKey=", // only print lines containing "deviceKey="
-                        TAG).get().trim();
-
-                if (log.contains(key)) {
-                    Log.d(TAG, "Found current device with id: " + device.deviceId);
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                AdbDevice device = findCurrentDevicePreO(devices);
+                if (device != null) {
+                    Log.d(TAG, "Found current device with serial: " + device.deviceId);
                     return device;
                 }
             }
+
+            AdbDevice device = findCurrentDevice(devices);
+            if (device != null) {
+                Log.d(TAG, "Found current device with id: " + device.deviceId);
+                return device;
+            }
+
             Log.w(TAG, "Could not find current device in 'adb devices', assuming it is the only device attached...");
         } catch (Exception e) {
             Log.w(TAG, "Could not find current device in 'adb devices', assuming it is the only device attached...", e);
         }
         return new AdbDevice(host, port, null);
+    }
+
+    // Suppressing the serial identifier warning, as we need a guaranteed unique ID for all devices
+    @SuppressLint("HardwareIds")
+    @TargetApi(Build.VERSION_CODES.O)
+    @Nullable
+    private static AdbDevice findCurrentDevicePreO(List<AdbDevice> devices) {
+        // first try using device serial
+        String serial = Build.SERIAL;
+        for (AdbDevice device : devices) {
+            if (serial.equals(device.deviceId)) {
+                return device;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static AdbDevice findCurrentDevice(List<AdbDevice> devices) throws Exception {
+        // to find this device, we log a random string and then check every device's logcat for it.
+        String key = String.format("deviceKey=%s", Integer.toHexString(new Random().nextInt()));
+
+        for (AdbDevice device : devices) {
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.SECOND, -5);  // so that -t <timestamp> has some buffer
+            String timestamp = LOGCAT_DATE_FORMAT.format(cal.getTime());
+
+            Log.v(TAG, key);
+
+            // find the above ButlerService log entry
+            String log = device.shellCommand("logcat",
+                    "-t", timestamp,    // only entries from last 5 seconds
+                    "-s",               // silence all tags (besides TAG)
+                    "-e", "deviceKey=", // only print lines containing "deviceKey="
+                    TAG).get().get().trim();
+
+            if (log.contains(key)) {
+                return device;
+            }
+        }
+        return null;
     }
 
     /**
@@ -130,8 +139,8 @@ class AdbDevice {
      * @param port The ADB server port
      * @return A list of AdbDevice instances. Each AdbDevice has an explicit DeviceId.
      */
-    private static List<AdbDevice> getDevices(String host, int port) throws InterruptedException, ExecutionException {
-        String result = send(host, port, AdbCommand.getDevices()).get();
+    private static List<AdbDevice> getDevices(String host, int port) throws Exception {
+        String result = send(host, port, AdbCommand.getDevices()).get().get();
         ArrayList<AdbDevice> devices = new ArrayList<>();
         for (String line : result.trim().split("\n")) {
             String[] parts = line.split("\t");
@@ -161,7 +170,30 @@ class AdbDevice {
         return send(host, port, AdbCommand.shell(deviceId, command, args));
     }
 
-    static class AdbCommandTask extends AsyncTask<Void, Void, String> {
+    private static class Result {
+        private final String result;
+        private final Exception exception;
+
+        private Result(@Nullable String result) {
+            this.result = result;
+            this.exception = null;
+        }
+
+        private Result(@NonNull Exception exception) {
+            this.result = null;
+            this.exception = exception;
+        }
+
+        @Nullable
+        String get() throws Exception {
+            if (exception != null) {
+                throw exception;
+            }
+            return result;
+        }
+    }
+
+    static class AdbCommandTask extends AsyncTask<Void, Void, Result> {
         private final String host;
         private final int port;
         private final AdbCommand command;
@@ -174,16 +206,16 @@ class AdbDevice {
         }
 
         @Override
-        protected String doInBackground(Void... ignored) {
+        protected Result doInBackground(Void... ignored) {
             Log.d(TAG, "Executing command: " + command);
             try (Socket socket = this.socket) {
                 socket.connect(new InetSocketAddress(host, port));
                 AdbConnection connection = new AdbConnection(socket);
                 String response = command.execute(connection);
                 Log.d(TAG, "Command '" + command + "' returned " + response);
-                return response;
+                return new Result(response);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                return new Result(e);
             }
         }
 

--- a/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ActivityManagerWrapper.java
+++ b/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ActivityManagerWrapper.java
@@ -45,37 +45,28 @@ class ActivityManagerWrapper {
 
     void broadcastIntent(Intent intent) throws RemoteException {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            broadcastIntentPreM(null, intent, intent.getType(), null, 0, null, null, null, -1, true, false, CURRENT_USER_ID);
+            broadcastIntentPreM(intent);
         } else {
-            broadcastIntent(null, intent, intent.getType(), null, 0, null, null, null, -1, null, true, false, CURRENT_USER_ID);
+            broadcastIntentPostM(intent);
         }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
-    private int broadcastIntent(Object iApplicationThreadCaller, Intent intent,
-                                String resolvedType, Object iIntentReceiverResultTo, int resultCode,
-                                String resultData, Bundle map, String[] requiredPermissions,
-                                int appOp, Bundle options, boolean serialized, boolean sticky,
-                                int userId) throws RemoteException {
+    private void broadcastIntentPostM(Intent intent) throws RemoteException {
         try {
-            return (int) broadcastIntent.invoke(iActivityManager, iApplicationThreadCaller, intent,
-                    resolvedType, iIntentReceiverResultTo, resultCode, resultData, map,
-                    requiredPermissions, appOp, options, serialized, sticky, userId);
+            broadcastIntent.invoke(iActivityManager, null, intent, intent.getType(), null, 0, null,
+                    null, null, -1, null, true, false, CURRENT_USER_ID);
         } catch (Exception e) {
             throw ExceptionCreator.createRemoteException(TAG, "Failed to broadcast intent", e);
         }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-    int broadcastIntentPreM(Object iApplicationThreadCaller, Intent intent,
-                            String resolvedType, Object iIntentReceiverResultTo, int resultCode,
-                            String resultData, Bundle map, String requiredPermissions,
-                            int appOp, boolean serialized, boolean sticky, int userId)
+    private void broadcastIntentPreM(Intent intent)
             throws RemoteException {
         try {
-            return (int) broadcastIntent.invoke(iActivityManager, iApplicationThreadCaller, intent,
-                    resolvedType, iIntentReceiverResultTo, resultCode, resultData, map,
-                    requiredPermissions, appOp, serialized, sticky, userId);
+            broadcastIntent.invoke(iActivityManager, null, intent, intent.getType(), null, 0, null,
+                    null, null, -1, true, false, CURRENT_USER_ID);
         } catch (Exception e) {
             throw ExceptionCreator.createRemoteException(TAG, "Failed to broadcast intent", e);
         }

--- a/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ActivityManagerWrapper.java
+++ b/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ActivityManagerWrapper.java
@@ -15,9 +15,13 @@
  */
 package com.linkedin.android.testbutler.shell;
 
+import android.annotation.TargetApi;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.RemoteException;
+
+import androidx.annotation.RequiresApi;
 
 import com.linkedin.android.testbutler.utils.ExceptionCreator;
 
@@ -29,6 +33,7 @@ import java.lang.reflect.Method;
 class ActivityManagerWrapper {
 
     private static final String TAG = ActivityManagerWrapper.class.getSimpleName();
+    private static final int CURRENT_USER_ID = -2;
 
     private final Method broadcastIntent;
     private final Object iActivityManager;
@@ -38,15 +43,39 @@ class ActivityManagerWrapper {
         this.iActivityManager = iActivityManager;
     }
 
-    int broadcastIntent(Object iApplicationThreadCaller, Intent intent,
-                        String resolvedType, Object iIntentReceiverResultTo, int resultCode,
-                        String resultData, Bundle map, String[] requiredPermissions,
-                        int appOp, Bundle options, boolean serialized, boolean sticky,
-                        int userId) throws RemoteException {
+    void broadcastIntent(Intent intent) throws RemoteException {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            broadcastIntentPreM(null, intent, intent.getType(), null, 0, null, null, null, -1, true, false, CURRENT_USER_ID);
+        } else {
+            broadcastIntent(null, intent, intent.getType(), null, 0, null, null, null, -1, null, true, false, CURRENT_USER_ID);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private int broadcastIntent(Object iApplicationThreadCaller, Intent intent,
+                                String resolvedType, Object iIntentReceiverResultTo, int resultCode,
+                                String resultData, Bundle map, String[] requiredPermissions,
+                                int appOp, Bundle options, boolean serialized, boolean sticky,
+                                int userId) throws RemoteException {
         try {
             return (int) broadcastIntent.invoke(iActivityManager, iApplicationThreadCaller, intent,
                     resolvedType, iIntentReceiverResultTo, resultCode, resultData, map,
                     requiredPermissions, appOp, options, serialized, sticky, userId);
+        } catch (Exception e) {
+            throw ExceptionCreator.createRemoteException(TAG, "Failed to broadcast intent", e);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
+    int broadcastIntentPreM(Object iApplicationThreadCaller, Intent intent,
+                            String resolvedType, Object iIntentReceiverResultTo, int resultCode,
+                            String resultData, Bundle map, String requiredPermissions,
+                            int appOp, boolean serialized, boolean sticky, int userId)
+            throws RemoteException {
+        try {
+            return (int) broadcastIntent.invoke(iActivityManager, iApplicationThreadCaller, intent,
+                    resolvedType, iIntentReceiverResultTo, resultCode, resultData, map,
+                    requiredPermissions, appOp, serialized, sticky, userId);
         } catch (Exception e) {
             throw ExceptionCreator.createRemoteException(TAG, "Failed to broadcast intent", e);
         }
@@ -60,11 +89,20 @@ class ActivityManagerWrapper {
 
             Object iActivityManager = activityManagerClass.getMethod("getDefault").invoke(null);
 
-            Method broadcastIntent = iActivityManager.getClass().getMethod("broadcastIntent",
-                    iApplicationThreadClass, Intent.class, String.class, iIntentReceiverClass,
-                    int.class, String.class, Bundle.class, String[].class, int.class, Bundle.class,
-                    boolean.class, boolean.class, int.class);
+            Method broadcastIntent;
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                broadcastIntent = iActivityManager.getClass().getMethod("broadcastIntent",
+                        iApplicationThreadClass, Intent.class, String.class, iIntentReceiverClass,
+                        int.class, String.class, Bundle.class, String.class, int.class,
+                        boolean.class, boolean.class, int.class);
+            } else {
+                broadcastIntent = iActivityManager.getClass().getMethod("broadcastIntent",
+                        iApplicationThreadClass, Intent.class, String.class, iIntentReceiverClass,
+                        int.class, String.class, Bundle.class, String[].class, int.class, Bundle.class,
+                        boolean.class, boolean.class, int.class);
+            }
             return new ActivityManagerWrapper(broadcastIntent, iActivityManager);
+
         } catch (Exception e) {
             throw new RuntimeException("Failed to initialize ActivityManagerWrapper", e);
         }

--- a/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ShellButlerService.java
+++ b/test-butler-app-physical-devices/src/main/java/com/linkedin/android/testbutler/shell/ShellButlerService.java
@@ -51,8 +51,6 @@ public class ShellButlerService implements Closeable {
 
     static final String SHELL_PACKAGE = "com.android.shell";
 
-    private static final int CURRENT_USER_ID = -2;
-
     private final CountDownLatch stop = new CountDownLatch(1);
     private final ShellSettingsAccessor settings;
 
@@ -148,8 +146,7 @@ public class ShellButlerService implements Closeable {
         BundleCompat.putBinder(bundle, BUTLER_API_BUNDLE_KEY, butlerApi);
         intent.putExtra(BUTLER_API_BUNDLE_KEY, bundle);
 
-        ActivityManagerWrapper.newInstance().broadcastIntent(null, intent, intent.getType(), null,
-                0, null, null, null, -1, null, true, false, CURRENT_USER_ID);
+        ActivityManagerWrapper.newInstance().broadcastIntent(intent);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
* Add support for physical devices at API 21 and 22 (Previous broadcastIntent method used wrong signature for those API levels). Note: API <21 is not supported, because 'adb reverse' was only added at Android 5.0 (API 21).
* Change device lookup by Build.SERIAL to fallback to logcat approach, because some serials do not match what ADB displays.
* Handle errors in ADB commands.