### PR TITLE
Bump versions to 2.1.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 2.1.0 (2019-11-19)
+
+- Allow TestButler to simulate an AccessibilityService during tests
+
 ## Version 2.0.2 (2019-11-8)
 
 - Fix crashes in test-butler library by publishing new `test-butler-api` artifact

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ artifactory {
         defaults {
             publications 'apiLib', 'ivyApiLib',
                     'lib', 'ivyLib',
-                    'apk', 'ivyApk',
+                    'apk', 'ivyApk'
                     // 'physicalDeviceApk', 'ivyPhysicalDeviceApk'
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Djava.awt.headless=true
 org.gradle.daemon=false
 
 GROUP_ID=com.linkedin.testbutler
-VERSION_NAME=2.0.3-SNAPSHOT
+VERSION_NAME=2.1.0-SNAPSHOT
 
 android.useAndroidX=true


### PR DESCRIPTION
We're bumping the minor version to indicate the introduction of the new AccessibilityService feature.