### PR TITLE
Increase timeout for TestButler service binding

### DIFF
--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -110,7 +110,7 @@ public class TestButler {
 
         context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
         try {
-            if (!serviceStarted.await(5, TimeUnit.SECONDS)) {
+            if (!serviceStarted.await(15, TimeUnit.SECONDS)) {
                 Log.e(TAG, "Failed to start TestButler; Did you remember to install it before running your tests?\n" +
                         "Running tests without ButlerService, failures or unexpected behavior may occur!!!");
             }


### PR DESCRIPTION
Sometimes TestButler does not start within 5s on certain APIs or in certain loaded environments, causing failures. Bumping the timeout to 15s fixes the situation.